### PR TITLE
Avoid unintentionally bundling with JUnit 3 → disable copy plugin by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,7 @@
                             </artifactItems>
                             <outputDirectory>${project.basedir}/src/main/resources/META-INF/rewrite/classpath</outputDirectory>
                             <overWriteSnapshots>true</overWriteSnapshots>
+                            <skip>true</skip>   <!-- ← Disabled for now, remove this line to activate it -->
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,8 @@
                             </artifactItems>
                             <outputDirectory>${project.basedir}/src/main/resources/META-INF/rewrite/classpath</outputDirectory>
                             <overWriteSnapshots>true</overWriteSnapshots>
-                            <skip>true</skip>   <!-- ← Disabled for now, remove this line to activate it -->
+                            <!-- Configure and enable plugin when you use `classpathFromResources` in `JavaTemplate` -->
+                            <skip>true</skip>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
After having applied the latest updates to my project, i was surprised finding a JUnit 3 jar in `src/main/resources/META-INF/rewrite/classpath/` (blast from the past :laughing: ).

If not actively removed this:
1. increases the compiled project's JAR by ~400 % (in my case it went from ~20Kb to ~127Kb)
1. adds a legacy dependency to the classpath that most probably most consumers of the starter template won't need
1. would increase the likelihood that the JUnit3 JAR accidentally gets added to the repo on `git add .`

Therefore i propose to keep the copy plugin disabled by default, as this makes for a better DX when traded off against the above points.

Point 3. begs the question whether `src/main/resources/META-INF/rewrite/classpath/` shouldn't also be added to `.gitignore`?