### PR TITLE
Fix MethodMatcher syntax for NEW_ARRAY_LIST_MATCHER

### DIFF
--- a/src/main/java/com/yourorg/NoCollectionMutation.java
+++ b/src/main/java/com/yourorg/NoCollectionMutation.java
@@ -78,7 +78,7 @@ public class NoCollectionMutation extends Recipe {
                SORT_MATCHER.matches(mt);
     }
 
-    private static final MethodMatcher NEW_ARRAY_LIST_MATCHER = new MethodMatcher("java.util.ArrayList <init>(java.util.Collection)");
+    private static final MethodMatcher NEW_ARRAY_LIST_MATCHER = new MethodMatcher("java.util.ArrayList <constructor>(java.util.Collection)");
 
     /**
      * @param cursor a stack of LST elements with parent/child relationships connecting an individual LST element to the root of the tree


### PR DESCRIPTION
The MerhodMatcher syntax used in the NoCollectionMutation example for NEW_ARRAY_LIST_MATCHER is incorrect and prints an error while running unit tests. I suspect `<init>` was an earlier syntax for `<constructor>`.