### PR TITLE
fix the broken links in the READMEmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To begin, fork this repository and customize it by:
 
 ## Getting started
 
-Familiarize yourself with the [OpenRewrite documentation](https://docs.openrewrite.org/), in particular the [concepts & explanations](https://docs.openrewrite.org/concepts-explanations) op topics like the [lossless semantic trees](https://docs.openrewrite.org/concepts-explanations/lossless-semantic-trees), [recipes](https://docs.openrewrite.org/concepts-explanations/recipes) and [visitors](https://docs.openrewrite.org/concepts-explanations/visitors).
+Familiarize yourself with the [OpenRewrite documentation](https://docs.openrewrite.org/), in particular the [concepts & explanations](https://docs.openrewrite.org/concepts-explanations) op topics like the [lossless semantic trees](https://docs.openrewrite.org/concepts-and-explanations/lossless-semantic-trees), [recipes](https://docs.openrewrite.org/concepts-and-explanations/recipes) and [visitors](https://docs.openrewrite.org/concepts-and-explanations/visitors).
 
 You might be interested to watch some of the [videos available on OpenRewrite and Moderne](https://www.youtube.com/@moderne-and-openrewrite).
 
@@ -140,7 +140,7 @@ To build a release, run `./gradlew final publish` to tag a release and publish i
 
 ## Applying OpenRewrite recipe development best practices
 
-We maintain a collection of [best practices for writing OpenRewrite recipes](https://docs.openrewrite.org/recipes/recipes/openrewritebestpractices).
+We maintain a collection of [best practices for writing OpenRewrite recipes](https://docs.openrewrite.org/recipes/java/recipes).
 You can apply these recommendations to your recipes by running the following command:
 
 ```bash


### PR DESCRIPTION
**What this does?**

Fixes the broken links in the `README.md`

**How?**

Documents appeared to have shifted around and the links were not updated.

for example:

`https://docs.openrewrite.org/concepts-explanations/lossless-semantic-trees` -> `https://docs.openrewrite.org/concepts-and-explanations/lossless-semantic-trees`

and 

`https://docs.openrewrite.org/recipes/recipes/openrewritebestpractices` -> `https://docs.openrewrite.org/recipes/java/recipes`

**How to test?**
- go to branch `https://github.com/moderneinc/rewrite-recipe-starter/tree/fix-README-links`
- click the updated links and they should now take you to the correct page