### PR TITLE
System separators for Trait example test

### DIFF
--- a/src/test/java/com/yourorg/FindSpringBeansTest.java
+++ b/src/test/java/com/yourorg/FindSpringBeansTest.java
@@ -18,6 +18,7 @@ package com.yourorg;
 import com.yourorg.table.SpringBeansReport;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.PathUtils;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -40,7 +41,7 @@ class FindSpringBeansTest implements RewriteTest {
     @DocumentExample
     @Test
     void findSpringBeans() {
-        String filePath = "src/main/java/com/yourorg/MyConfig.java";
+        String filePath = PathUtils.separatorsToSystem("src/main/java/com/yourorg/MyConfig.java");
         rewriteRun(
           spec -> spec.dataTable(SpringBeansReport.Row.class, rows ->
             assertThat(rows)


### PR DESCRIPTION
- fixes #76

**Description:**
This pull request introduces the following changes:

1. **Unit Test (`FindSpringBeansTest`):**
   - Wraps `filePath` in test with `PathUtils.separatorsToSystem()` to ensure that the separator is correct on the system on which the tests are being run (was previously comparing forward slashes to Windows's backslashes and failing).
