### PR TITLE
Two small fixes

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=17.0.12-tem
+java=21.0.7-tem

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,9 @@ dependencies {
     }
 
     // The RewriteTest class needed for testing recipes
-    testImplementation("org.openrewrite:rewrite-test")
+    testImplementation("org.openrewrite:rewrite-test") {
+        exclude(group = "org.slf4j", module = "slf4j-nop")
+    }
 
     // Need to have a slf4j binding to see any output enabled from the parser.
     runtimeOnly("ch.qos.logback:logback-classic:1.2.+")


### PR DESCRIPTION
Two fixes in preparing for virtual training:
- Move to Java 21 in `.sdkmanrc` since the build was moved to 21 in https://github.com/moderneinc/rewrite-recipe-starter/commit/a7141e79307a1fd658423817ab21556f1c3d8ef0.
- Exclude `slf4j-nop` to avoid conflict with `logback-classic`.