### PR TITLE
Configure Maven to use correct Java Versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- By convention, we develop recipes with Java 8 to be applicable to legacy code -->
-        <recipe.java.version>8</recipe.java.version>
+        <maven.compiler.release>8</maven.compiler.release>
         <!-- For tests, we recommend a java version newer than 15 to have textblocks available -->
-        <tests.java.version>21</tests.java.version>
+        <maven.compiler.testRelease>21</maven.compiler.testRelease>
     </properties>
 
     <dependencyManagement>
@@ -154,8 +154,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <source>${recipe.java.version}</source>
-                    <target>${recipe.java.version}</target>
                     <compilerArgs>
                         <arg>-parameters</arg>
                     </compilerArgs>
@@ -172,20 +170,6 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
-                <executions>
-                    <!-- allow different Java versions for tests than recipes. -->
-                    <execution>
-                        <id>test-compile</id>
-                        <phase>process-test-sources</phase>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                        <configuration>
-                            <source>${tests.java.version}</source>
-                            <target>${tests.java.version}</target>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <!-- By convention, we develop recipes with Java 8 to be applicable to legacy code -->
+        <recipe.java.version>8</recipe.java.version>
+        <!-- For tests, we recommend a java version newer than 15 to have textblocks available -->
+        <tests.java.version>21</tests.java.version>
     </properties>
 
     <dependencyManagement>
@@ -150,8 +154,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <source>${recipe.java.version}</source>
+                    <target>${recipe.java.version}</target>
                     <compilerArgs>
                         <arg>-parameters</arg>
                     </compilerArgs>
@@ -168,6 +172,20 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+                <executions>
+                    <!-- allow different Java versions for tests than recipes. -->
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>process-test-sources</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <source>${tests.java.version}</source>
+                            <target>${tests.java.version}</target>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -196,7 +214,7 @@
             <plugin>
                 <groupId>org.openrewrite.maven</groupId>
                 <artifactId>rewrite-maven-plugin</artifactId>
-                <version>6.12.1</version>
+                <version>6.15.0</version>
                 <configuration>
                     <failOnDryRunResults>true</failOnDryRunResults>
                 </configuration>
@@ -204,12 +222,12 @@
                     <dependency>
                         <groupId>org.openrewrite.recipe</groupId>
                         <artifactId>rewrite-migrate-java</artifactId>
-                        <version>3.12.0</version>
+                        <version>3.14.1</version>
                     </dependency>
                     <dependency>
                         <groupId>org.openrewrite.recipe</groupId>
                         <artifactId>rewrite-rewrite</artifactId>
-                        <version>0.8.0</version>
+                        <version>0.10.1</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -228,7 +246,7 @@
                     <plugin>
                         <groupId>org.openrewrite.maven</groupId>
                         <artifactId>rewrite-maven-plugin</artifactId>
-                        <version>6.12.0</version>
+                        <version>6.15.0</version>
                         <configuration>
                             <recipeArtifactCoordinates>
                                 junit:junit:3.8.1,

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -1,3 +1,13 @@
+# to use the IntelliJ OpenRewrite plugin run action need the
+# org.openrewrite.recipe:rewrite-rewrite dependency on the classpath.
+# For Maven projects
+#   <dependency>
+#     <groupId>org.openrewrite.recipe</groupId>
+#     <artifactId>rewrite-rewrite</artifactId>
+#   </dependency>
+# For Gradle projects
+#   runtimeOnly("org.openrewrite.recipe:rewrite-rewrite")
+
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: com.yourorg.ApplyRecipeBestPractices


### PR DESCRIPTION
This MR configures `pom.xml` to enforce different Java versions for the recipe source code and the test code. 
Aligned with the gradle configuration, the main code (recipes) is compiled with Java 8, while the tests are compiled with Java 21.