### PR TITLE
Make NoCollectionMutation idempotent for separate source/sink mutations

### DIFF
--- a/src/main/java/com/yourorg/NoCollectionMutation.java
+++ b/src/main/java/com/yourorg/NoCollectionMutation.java
@@ -114,6 +114,11 @@ public class NoCollectionMutation extends Recipe {
                             return m;
                         }
 
+                        // Already wrapped in a defensive copy (e.g. from a previous cycle); nothing to do.
+                        if (inDefensiveCopy(getCursor())) {
+                            return m;
+                        }
+
                         boolean isMutated = Dataflow.startingAt(getCursor()).findSinks(new DataFlowSpec() {
                                     @Override
                                     public boolean isSource(DataFlowNode srcNode) {


### PR DESCRIPTION
## Problem

CI on `main` is red: `NoCollectionMutationTest.subsequentMutation()` fails with

```
Expected recipe to complete in 1 cycle, but took at least one more cycle.
Between the last two executed cycles there were changes to "ManipulateMethodArguments.java"
```

(failing run: https://github.com/moderneinc/rewrite-recipe-starter/actions/runs/27818080247/job/82324204080)

The recipe wraps the list source in a defensive copy and produced
`new ArrayList<>(new ArrayList<>(method.getArguments()))`, never converging.

## Cause

`NoCollectionMutation` only checked whether the mutation **sink** was already inside a
defensive copy (`inDefensiveCopy(sink)`). In the `subsequentMutation` case the source
(`method.getArguments()`) is stored in a local variable that is mutated later, so the
defensive copy lands on the **source**, while the sink (`args.remove(0)`) stays unwrapped.
On each subsequent cycle the recipe re-wrapped the already-wrapped source.

## Fix

Also guard the source: if the current method invocation is already inside a defensive-copy
`ArrayList` constructor, return it unchanged. The recipe now converges in a single cycle.

`./gradlew build test` passes locally.