### PR TITLE
docs: clarify that org.openrewrite.build.publish pins dynamic versions in the published POM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,13 @@
 plugins {
     id("org.openrewrite.build.recipe-library-base") version "latest.release"
 
-    // This uses the nexus publishing plugin to publish to the moderne-dev repository
-    // Remove it if you prefer to publish by other means, such as the maven-publish plugin
+    // Publishes to the moderne-dev repository via the nexus publishing plugin. It also
+    // applies Nebula's MavenResolvedDependenciesPlugin, which pins dynamic versions
+    // (e.g. "1.5.+", "latest.release") to the concrete versions Gradle resolved when
+    // writing the published POM. If you replace this with the plain maven-publish plugin,
+    // add `versionMapping { allVariants { fromResolutionResult() } }` to your publication --
+    // otherwise dynamic versions are published verbatim and consumers resolving the recipe
+    // through a private/virtual Maven repository may fail to resolve them.
     id("org.openrewrite.build.publish") version "latest.release"
     id("nebula.release") version "latest.release"
 
@@ -77,6 +82,20 @@ configure<PublishingExtension> {
         named("nebula", MavenPublication::class.java) {
             suppressPomMetadataWarningsFor("runtimeElements")
         }
+
+        // If you replace `org.openrewrite.build.publish` above with the plain `maven-publish`
+        // plugin, uncomment the block below so dynamic versions (e.g. "1.5.+", "latest.release")
+        // are pinned to the concrete versions Gradle resolved when the POM is written. Without
+        // it those selectors are published verbatim and consumers resolving the recipe through a
+        // private/virtual Maven repository may fail to resolve them.
+        //
+        // withType<MavenPublication> {
+        //     versionMapping {
+        //         allVariants {
+        //             fromResolutionResult()
+        //         }
+        //     }
+        // }
     }
 }
 


### PR DESCRIPTION
## Why

The `plugins {}` block comment currently invites a footgun: it says you can drop `org.openrewrite.build.publish` in favor of the plain `maven-publish` plugin, without mentioning a load-bearing side effect.

`org.openrewrite.build.publish` (→ `RewritePublishPlugin`) applies Nebula's [`MavenResolvedDependenciesPlugin`](https://github.com/openrewrite/rewrite-build-gradle-plugin/blob/main/src/main/java/org/openrewrite/gradle/RewritePublishPlugin.java#L52), which rewrites the **published POM** to pin dynamic version selectors to the concrete versions Gradle resolved. For example, line 56's `runtimeOnly("ch.qos.logback:logback-classic:1.5.+")` is published as `1.5.34`, not `1.5.+`.

If you swap in plain `maven-publish`, that resolution is lost and the dynamic selector (`1.5.+`, `latest.release`) is written verbatim into the POM. Consumers then have to resolve it via `maven-metadata.xml`, which can fail when the recipe is pulled through a private/virtual Maven repository — exactly the kind of "Unable to resolve recipe … Failed to download pom for … `1.x.+`" error seen in locked-down environments.

## What

1. Clarify the plugins-block comment to explain the version-pinning behavior.
2. Add a commented-out `versionMapping { allVariants { fromResolutionResult() } }` publishing block, ready to uncomment for anyone who does switch to `maven-publish`, so they keep resolved-version POMs without having to look it up.

Docs/comments only; no build behavior changes (the added block is commented out).

## Verification

Publishing the starter to Maven Local produces a POM with the resolved version:

\`\`\`xml
<artifactId>logback-classic</artifactId>
<version>1.5.34</version>
<scope>runtime</scope>
\`\`\`