### PR TITLE
Unpin rewrite-maven-plugin and update pinned recipe versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,11 @@ updates:
       interval: weekly
     commit-message:
       prefix: "chore(ci)"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      openrewrite:
+        patterns:
+          - "org.openrewrite*:*"

--- a/pom.xml
+++ b/pom.xml
@@ -209,13 +209,12 @@
                 </configuration>
             </plugin>
             <!--
-                Only needed when you want to apply the OpenRewriteBestPractices recipe to your recipes through
+                This plugin is used to run best practices recipes and to regenerate the recipes.csv, e.g.:
                 ./mvnw rewrite:run -Drewrite.activeRecipes=com.yourorg.ApplyRecipeBestPractices
             -->
             <plugin>
                 <groupId>org.openrewrite.maven</groupId>
                 <artifactId>rewrite-maven-plugin</artifactId>
-                <version>6.23.0</version>
                 <configuration>
                     <failOnDryRunResults>true</failOnDryRunResults>
                 </configuration>
@@ -223,12 +222,12 @@
                     <dependency>
                         <groupId>org.openrewrite.recipe</groupId>
                         <artifactId>rewrite-migrate-java</artifactId>
-                        <version>3.21.2</version>
+                        <version>3.39.0</version>
                     </dependency>
                     <dependency>
                         <groupId>org.openrewrite.recipe</groupId>
                         <artifactId>rewrite-rewrite</artifactId>
-                        <version>0.15.0</version>
+                        <version>0.27.0</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -247,7 +246,6 @@
                     <plugin>
                         <groupId>org.openrewrite.maven</groupId>
                         <artifactId>rewrite-maven-plugin</artifactId>
-                        <version>6.22.1</version>
                         <configuration>
                             <recipeArtifactCoordinates>
                                 junit:junit:3.8.1,


### PR DESCRIPTION
The `rewrite-maven-plugin` is now used to regenerate `recipes.csv`, not just to run the best practices recipes.  The original comment made this seem optional and customers were sometimes dropping this plugin from their POM, meaning they could not regenerate the recipes.csv with `mvn rewrite:recipeCsvGenerate`.

The starter was also pinned to an older version of the plugin that didn't support this command at all, so I've dropped the explicit version to always use the latest. The pinned recipe dependencies are bumped (`rewrite-migrate-java` 3.21.2 → 3.39.0, `rewrite-rewrite` 0.15.0 → 0.27.0) and the plugin comment is updated to reflect its broader purpose.