### PR TITLE
Add Code Genome Project repository for OpenRewrite and Moderne artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,7 @@ env:
 
 jobs:
   gradle:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest"]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
@@ -39,11 +35,7 @@ jobs:
           ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN }}
 
   maven:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest"]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,17 @@ jobs:
         with:
           distribution: temurin
           java-version: 25
+          server-id: codegenome
+          server-username: CODEGENOME_USERNAME
+          server-password: CODEGENOME_TOKEN
       - uses: gradle/actions/setup-gradle@v6
       - name: build
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} build test
+        env:
+          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME }}
+          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN }}
       - name: verify
         run: mvn --show-version --no-transfer-progress --update-snapshots --fail-at-end --batch-mode -Dstyle.color=always verify
+        env:
+          CODEGENOME_USERNAME: ${{ secrets.CODEGENOME_USERNAME }}
+          CODEGENOME_TOKEN: ${{ secrets.CODEGENOME_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,28 @@ env:
   GRADLE_SWITCHES: '--console=plain --info --stacktrace'
 
 jobs:
-  build:
+  gradle:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+      - uses: gradle/actions/setup-gradle@v6
+      - name: build
+        run: ./gradlew ${{ env.GRADLE_SWITCHES }} build test
+        env:
+          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME }}
+          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN }}
+
+  maven:
     strategy:
       fail-fast: false
       matrix:
@@ -34,12 +55,6 @@ jobs:
           server-id: codegenome
           server-username: CODEGENOME_USERNAME
           server-password: CODEGENOME_TOKEN
-      - uses: gradle/actions/setup-gradle@v6
-      - name: build
-        run: ./gradlew ${{ env.GRADLE_SWITCHES }} build test
-        env:
-          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME }}
-          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN }}
       - name: verify
         run: mvn --show-version --no-transfer-progress --update-snapshots --fail-at-end --batch-mode -Dstyle.color=always verify
         env:

--- a/.github/workflows/maven-versions-use-latest-releases.yml
+++ b/.github/workflows/maven-versions-use-latest-releases.yml
@@ -19,8 +19,9 @@ jobs:
           distribution: temurin
           java-version: 25
           cache: maven
-          server-id: ossrh
-          settings-path: ${{ github.workspace }}
+          server-id: codegenome
+          server-username: CODEGENOME_USERNAME
+          server-password: CODEGENOME_TOKEN
       - name: configure-git-user
         run: |
           git config user.email "team@moderne.io"
@@ -30,3 +31,6 @@ jobs:
         run: |
           mvn versions:use-latest-releases
           git diff-index --quiet HEAD pom.xml || (git commit -m "Use latest releases for Maven" pom.xml && git push origin main && rm -f pom.xml.versionsBackup)
+        env:
+          CODEGENOME_USERNAME: ${{ secrets.CODEGENOME_USERNAME }}
+          CODEGENOME_TOKEN: ${{ secrets.CODEGENOME_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,25 @@ plugins {
 group = "com.yourorg"
 description = "Rewrite recipes."
 
+// Code Genome Project (Moderne-hosted) repository for OpenRewrite and Moderne artifacts.
+// Credentials are read from Gradle properties (e.g. ~/.gradle/gradle.properties) or the
+// ORG_GRADLE_PROJECT_codegenomeUsername / ORG_GRADLE_PROJECT_codegenomePassword environment
+// variables, and are intentionally kept out of source control.
+repositories {
+    maven {
+        name = "codegenome"
+        url = uri("https://artifacts.codegenomeproject.org/maven")
+        val codegenomeUsername = providers.gradleProperty("codegenomeUsername").orNull
+        val codegenomePassword = providers.gradleProperty("codegenomePassword").orNull
+        if (codegenomeUsername != null && codegenomePassword != null) {
+            credentials {
+                username = codegenomeUsername
+                password = codegenomePassword
+            }
+        }
+    }
+}
+
 recipeDependencies {
     parserClasspath("org.jspecify:jspecify:1.0.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,21 +22,16 @@ group = "com.yourorg"
 description = "Rewrite recipes."
 
 // Code Genome Project (Moderne-hosted) repository for OpenRewrite and Moderne artifacts.
-// Credentials are read from Gradle properties (e.g. ~/.gradle/gradle.properties) or the
-// ORG_GRADLE_PROJECT_codegenomeUsername / ORG_GRADLE_PROJECT_codegenomePassword environment
-// variables, and are intentionally kept out of source control.
+// Credentials come from Gradle properties `codegenomeUsername`/`codegenomePassword`
+// (e.g. ~/.gradle/gradle.properties) or the matching ORG_GRADLE_PROJECT_* environment
+// variables, and are kept out of source control. The typed PasswordCredentials accessor
+// makes Gradle fail fast when they are absent, instead of silently falling back to Maven
+// Central and resolving stale versions once new artifacts are no longer published there.
 repositories {
     maven {
         name = "codegenome"
         url = uri("https://artifacts.codegenomeproject.org/maven")
-        val codegenomeUsername = providers.gradleProperty("codegenomeUsername").orNull
-        val codegenomePassword = providers.gradleProperty("codegenomePassword").orNull
-        if (codegenomeUsername != null && codegenomePassword != null) {
-            credentials {
-                username = codegenomeUsername
-                password = codegenomePassword
-            }
-        }
+        credentials(PasswordCredentials::class)
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,20 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>codegenome</id>
+            <url>https://artifacts.codegenomeproject.org/maven</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>codegenome</id>
+            <url>https://artifacts.codegenomeproject.org/maven</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Adds the Moderne-hosted Code Genome Project Maven repository (`https://artifacts.codegenomeproject.org/maven`) as a source for OpenRewrite and Moderne artifacts in both build tools. `pom.xml` gains `<repositories>` and `<pluginRepositories>` entries, and `build.gradle.kts` adds a matching `maven { }` repository. Gradle credentials are read from Gradle properties (`codegenomeUsername`/`codegenomePassword`) and Maven credentials from `~/.m2/settings.xml`, so no tokens are committed. Verified that both Maven and Gradle resolve OpenRewrite artifacts through the repository against the live endpoint.