### PR TITLE
Make Code Genome Project credentials optional until the cutover

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ You might be interested to watch some of the [videos available on OpenRewrite an
 Once you want to dive into the code there is a [comprehensive getting started guide](https://docs.openrewrite.org/authoring-recipes/recipe-development-environment)
 available in the OpenRewrite docs that provides more details than the below README.
 
+### Code Genome Project credentials
+
+OpenRewrite and Moderne artifacts are moving to the Code Genome Project repository on
+2026-08-12. Until then they remain on Maven Central and credentials are optional: the build
+only uses the Code Genome Project repository when credentials are present, and otherwise
+resolves from Maven Central.
+
+To use it before the cutover, set `codegenomeUsername`/`codegenomePassword` in
+`~/.gradle/gradle.properties` for Gradle, and add a `codegenome` server to your
+`~/.m2/settings.xml` plus set `CODEGENOME_USERNAME` in your environment for Maven, which
+activates the matching `codegenome` profile. After the cutover these become required.
+
 ## Reference recipes
 
 * [META-INF/rewrite/stringutils.yml](./src/main/resources/META-INF/rewrite/stringutils.yml) - A declarative YAML recipe that replaces usages of `org.springframework.util.StringUtils` with `org.apache.commons.lang3.StringUtils`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,15 +24,28 @@ description = "Rewrite recipes."
 // Code Genome Project (Moderne-hosted) repository for OpenRewrite and Moderne artifacts.
 // Credentials come from Gradle properties `codegenomeUsername`/`codegenomePassword`
 // (e.g. ~/.gradle/gradle.properties) or the matching ORG_GRADLE_PROJECT_* environment
-// variables, and are kept out of source control. The typed PasswordCredentials accessor
-// makes Gradle fail fast when they are absent, instead of silently falling back to Maven
-// Central and resolving stale versions once new artifacts are no longer published there.
-repositories {
-    maven {
-        name = "codegenome"
-        url = uri("https://artifacts.codegenomeproject.org/maven")
-        credentials(PasswordCredentials::class)
+// variables, and are kept out of source control.
+//
+// Until the 2026-08-12 cutover the artifacts are still published to Maven Central, so the
+// repository is only declared when credentials are available; builds without them keep
+// resolving from Maven Central. After the cutover, drop this conditional and use
+// `credentials(PasswordCredentials::class)` so the build fails fast on missing credentials
+// instead of silently resolving stale versions from Maven Central.
+val codegenomeUsername = providers.gradleProperty("codegenomeUsername").orNull?.takeIf { it.isNotBlank() }
+val codegenomePassword = providers.gradleProperty("codegenomePassword").orNull?.takeIf { it.isNotBlank() }
+if (codegenomeUsername != null && codegenomePassword != null) {
+    repositories {
+        maven {
+            name = "codegenome"
+            url = uri("https://artifacts.codegenomeproject.org/maven")
+            credentials {
+                username = codegenomeUsername
+                password = codegenomePassword
+            }
+        }
     }
+} else {
+    logger.lifecycle("No codegenomeUsername/codegenomePassword found; resolving from Maven Central. Set them before the 2026-08-12 Code Genome Project cutover.")
 }
 
 recipeDependencies {

--- a/pom.xml
+++ b/pom.xml
@@ -163,20 +163,6 @@
         </dependency>
     </dependencies>
 
-    <repositories>
-        <repository>
-            <id>codegenome</id>
-            <url>https://artifacts.codegenomeproject.org/maven</url>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>codegenome</id>
-            <url>https://artifacts.codegenomeproject.org/maven</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <build>
         <plugins>
             <plugin>
@@ -249,6 +235,34 @@
     </build>
 
     <profiles>
+        <!--
+            The Code Genome Project repository rejects anonymous requests, so declaring it
+            unconditionally makes every lookup 401 for contributors without credentials. Until the
+            2026-08-12 cutover the artifacts are still on Maven Central, so it is only added when
+            CODEGENOME_USERNAME is set to pair with the matching settings.xml server. After the
+            cutover, move these out of the profile so all builds resolve from it.
+        -->
+        <profile>
+            <id>codegenome</id>
+            <activation>
+                <property>
+                    <name>env.CODEGENOME_USERNAME</name>
+                </property>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>codegenome</id>
+                    <url>https://artifacts.codegenomeproject.org/maven</url>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>codegenome</id>
+                    <url>https://artifacts.codegenomeproject.org/maven</url>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+
         <!--
             When you want to generate a TypeTable for use in JavaParser for JavaTemplate, run the following command:
             ./mvnw generate-resources -Ptypetable


### PR DESCRIPTION
Artifacts remain on Maven Central until the 2026-08-12 cutover, so this makes the Code Genome Project repository opt-in rather than required.

Gradle previously used the typed `PasswordCredentials` accessor, which fails configuration outright when the properties are absent; it now declares the repository only when both properties resolve to non-blank values, logging a notice pointing at the cutover otherwise. Maven declared the repository unconditionally without credentials, so every lookup returned 401 before falling back to Maven Central — the repository and pluginRepository now live in a `codegenome` profile activated by `env.CODEGENOME_USERNAME`.

I verified profile activation across all three env-var states: Maven treats an empty value as unset, so CI runs without the secret (fork PRs, or repos where it is unset) stay on Maven Central instead of activating a profile that cannot authenticate. `compileJava` and `dependency:resolve` both succeed with no credentials, and no workflow changes were needed since the existing secret plumbing now degrades gracefully.

The README gains a short section on the cutover and how to opt in, and both build files carry comments on what to revert once the cutover lands.