### PR TITLE
Resolve artifacts from the Code Genome Project repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,6 @@ You might be interested to watch some of the [videos available on OpenRewrite an
 Once you want to dive into the code there is a [comprehensive getting started guide](https://docs.openrewrite.org/authoring-recipes/recipe-development-environment)
 available in the OpenRewrite docs that provides more details than the below README.
 
-### Code Genome Project credentials
-
-OpenRewrite and Moderne artifacts are moving to the Code Genome Project repository on
-2026-08-12. Until then they remain on Maven Central and credentials are optional: the build
-only uses the Code Genome Project repository when credentials are present, and otherwise
-resolves from Maven Central.
-
-To use it before the cutover, set `codegenomeUsername`/`codegenomePassword` in
-`~/.gradle/gradle.properties` for Gradle, and add a `codegenome` server to your
-`~/.m2/settings.xml` plus set `CODEGENOME_USERNAME` in your environment for Maven, which
-activates the matching `codegenome` profile. After the cutover these become required.
-
 ## Reference recipes
 
 * [META-INF/rewrite/stringutils.yml](./src/main/resources/META-INF/rewrite/stringutils.yml) - A declarative YAML recipe that replaces usages of `org.springframework.util.StringUtils` with `org.apache.commons.lang3.StringUtils`.

--- a/README.md
+++ b/README.md
@@ -21,14 +21,13 @@ available in the OpenRewrite docs that provides more details than the below READ
 
 ### Code Genome Project credentials
 
-OpenRewrite and Moderne artifacts are published to the Code Genome Project repository, which
-rejects anonymous requests. Without credentials dependencies do not resolve, so set them up
-before building.
+OpenRewrite and Moderne artifacts are only available from the Code Genome Project repository,
+which requires credentials. Without them dependencies do not resolve, so set them up before
+building.
 
 For Gradle, set `codegenomeUsername` and `codegenomePassword` in `~/.gradle/gradle.properties`,
 or use the matching `ORG_GRADLE_PROJECT_codegenomeUsername`/`ORG_GRADLE_PROJECT_codegenomePassword`
-environment variables. The build fails immediately when they are absent, rather than silently
-falling back to Maven Central and resolving stale versions.
+environment variables. The build fails immediately when they are absent.
 
 For Maven, add a `codegenome` server matching the repository id in `pom.xml` to your
 `~/.m2/settings.xml`:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,28 @@ You might be interested to watch some of the [videos available on OpenRewrite an
 Once you want to dive into the code there is a [comprehensive getting started guide](https://docs.openrewrite.org/authoring-recipes/recipe-development-environment)
 available in the OpenRewrite docs that provides more details than the below README.
 
+### Code Genome Project credentials
+
+OpenRewrite and Moderne artifacts are published to the Code Genome Project repository, which
+rejects anonymous requests. Without credentials dependencies do not resolve, so set them up
+before building.
+
+For Gradle, set `codegenomeUsername` and `codegenomePassword` in `~/.gradle/gradle.properties`,
+or use the matching `ORG_GRADLE_PROJECT_codegenomeUsername`/`ORG_GRADLE_PROJECT_codegenomePassword`
+environment variables. The build fails immediately when they are absent, rather than silently
+falling back to Maven Central and resolving stale versions.
+
+For Maven, add a `codegenome` server matching the repository id in `pom.xml` to your
+`~/.m2/settings.xml`:
+
+```xml
+<server>
+    <id>codegenome</id>
+    <username>your-username</username>
+    <password>your-token</password>
+</server>
+```
+
 ## Reference recipes
 
 * [META-INF/rewrite/stringutils.yml](./src/main/resources/META-INF/rewrite/stringutils.yml) - A declarative YAML recipe that replaces usages of `org.springframework.util.StringUtils` with `org.apache.commons.lang3.StringUtils`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,28 +24,15 @@ description = "Rewrite recipes."
 // Code Genome Project (Moderne-hosted) repository for OpenRewrite and Moderne artifacts.
 // Credentials come from Gradle properties `codegenomeUsername`/`codegenomePassword`
 // (e.g. ~/.gradle/gradle.properties) or the matching ORG_GRADLE_PROJECT_* environment
-// variables, and are kept out of source control.
-//
-// Until the 2026-08-12 cutover the artifacts are still published to Maven Central, so the
-// repository is only declared when credentials are available; builds without them keep
-// resolving from Maven Central. After the cutover, drop this conditional and use
-// `credentials(PasswordCredentials::class)` so the build fails fast on missing credentials
-// instead of silently resolving stale versions from Maven Central.
-val codegenomeUsername = providers.gradleProperty("codegenomeUsername").orNull?.takeIf { it.isNotBlank() }
-val codegenomePassword = providers.gradleProperty("codegenomePassword").orNull?.takeIf { it.isNotBlank() }
-if (codegenomeUsername != null && codegenomePassword != null) {
-    repositories {
-        maven {
-            name = "codegenome"
-            url = uri("https://artifacts.codegenomeproject.org/maven")
-            credentials {
-                username = codegenomeUsername
-                password = codegenomePassword
-            }
-        }
+// variables, and are kept out of source control. The typed PasswordCredentials accessor
+// makes Gradle fail fast when they are absent, instead of silently falling back to Maven
+// Central and resolving stale versions once new artifacts are no longer published there.
+repositories {
+    maven {
+        name = "codegenome"
+        url = uri("https://artifacts.codegenomeproject.org/maven")
+        credentials(PasswordCredentials::class)
     }
-} else {
-    logger.lifecycle("No codegenomeUsername/codegenomePassword found; resolving from Maven Central. Set them before the 2026-08-12 Code Genome Project cutover.")
 }
 
 recipeDependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,12 +21,9 @@ plugins {
 group = "com.yourorg"
 description = "Rewrite recipes."
 
-// The recipe-repositories plugin adds the Code Genome Project (Moderne-hosted) repository
-// for OpenRewrite and Moderne artifacts, but only when credentials are present; without them
-// it silently falls back to Maven Central and resolves stale versions once new artifacts are
-// no longer published there. Fail fast instead. Credentials come from Gradle properties
-// `codegenomeUsername`/`codegenomePassword` (e.g. ~/.gradle/gradle.properties) or the matching
-// ORG_GRADLE_PROJECT_* environment variables, and are kept out of source control.
+// OpenRewrite and Moderne artifacts are only available from the Code Genome Project repository,
+// which requires credentials. The recipe-repositories plugin adds that repository only when the
+// `codegenomeUsername`/`codegenomePassword` Gradle properties are set, so fail fast without them.
 require(
     providers.gradleProperty("codegenomeUsername").isPresent &&
         providers.gradleProperty("codegenomePassword").isPresent

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,16 @@ require(
         "https://artifacts.codegenomeproject.org/maven"
 }
 
+// org.openrewrite.tools artifacts are not published to the Code Genome Project repository, while
+// the recipe-repositories plugin excludes org.openrewrite and its subgroups from Maven Central.
+repositories {
+    mavenCentral {
+        content {
+            includeGroupAndSubgroups("org.openrewrite.tools")
+        }
+    }
+}
+
 recipeDependencies {
     parserClasspath("org.jspecify:jspecify:1.0.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,18 +21,18 @@ plugins {
 group = "com.yourorg"
 description = "Rewrite recipes."
 
-// Code Genome Project (Moderne-hosted) repository for OpenRewrite and Moderne artifacts.
-// Credentials come from Gradle properties `codegenomeUsername`/`codegenomePassword`
-// (e.g. ~/.gradle/gradle.properties) or the matching ORG_GRADLE_PROJECT_* environment
-// variables, and are kept out of source control. The typed PasswordCredentials accessor
-// makes Gradle fail fast when they are absent, instead of silently falling back to Maven
-// Central and resolving stale versions once new artifacts are no longer published there.
-repositories {
-    maven {
-        name = "codegenome"
-        url = uri("https://artifacts.codegenomeproject.org/maven")
-        credentials(PasswordCredentials::class)
-    }
+// The recipe-repositories plugin adds the Code Genome Project (Moderne-hosted) repository
+// for OpenRewrite and Moderne artifacts, but only when credentials are present; without them
+// it silently falls back to Maven Central and resolves stale versions once new artifacts are
+// no longer published there. Fail fast instead. Credentials come from Gradle properties
+// `codegenomeUsername`/`codegenomePassword` (e.g. ~/.gradle/gradle.properties) or the matching
+// ORG_GRADLE_PROJECT_* environment variables, and are kept out of source control.
+require(
+    providers.gradleProperty("codegenomeUsername").isPresent &&
+        providers.gradleProperty("codegenomePassword").isPresent
+) {
+    "Set the codegenomeUsername and codegenomePassword Gradle properties to resolve from " +
+        "https://artifacts.codegenomeproject.org/maven"
 }
 
 recipeDependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,16 +32,6 @@ require(
         "https://artifacts.codegenomeproject.org/maven"
 }
 
-// org.openrewrite.tools artifacts are not published to the Code Genome Project repository, while
-// the recipe-repositories plugin excludes org.openrewrite and its subgroups from Maven Central.
-repositories {
-    mavenCentral {
-        content {
-            includeGroupAndSubgroups("org.openrewrite.tools")
-        }
-    }
-}
-
 recipeDependencies {
     parserClasspath("org.jspecify:jspecify:1.0.0")
 }
@@ -50,6 +40,13 @@ dependencies {
     // The bom version can also be set to a specific version
     // https://github.com/openrewrite/rewrite-recipe-bom/releases
     implementation(platform("org.openrewrite.recipe:rewrite-recipe-bom:latest.release"))
+
+    // The bom still resolves rewrite-core versions that request java-object-diff 1.0.1, which is
+    // not published to the Code Genome Project repository; 1.0.2 is, and is what newer rewrite-core
+    // versions use.
+    constraints {
+        implementation("org.openrewrite.tools:java-object-diff:1.0.2")
+    }
 
     implementation("org.openrewrite:rewrite-java")
     implementation("org.openrewrite.recipe:rewrite-java-dependencies")

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,20 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>codegenome</id>
+            <url>https://artifacts.codegenomeproject.org/maven</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>codegenome</id>
+            <url>https://artifacts.codegenomeproject.org/maven</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <build>
         <plugins>
             <plugin>
@@ -235,34 +249,6 @@
     </build>
 
     <profiles>
-        <!--
-            The Code Genome Project repository rejects anonymous requests, so declaring it
-            unconditionally makes every lookup 401 for contributors without credentials. Until the
-            2026-08-12 cutover the artifacts are still on Maven Central, so it is only added when
-            CODEGENOME_USERNAME is set to pair with the matching settings.xml server. After the
-            cutover, move these out of the profile so all builds resolve from it.
-        -->
-        <profile>
-            <id>codegenome</id>
-            <activation>
-                <property>
-                    <name>env.CODEGENOME_USERNAME</name>
-                </property>
-            </activation>
-            <repositories>
-                <repository>
-                    <id>codegenome</id>
-                    <url>https://artifacts.codegenomeproject.org/maven</url>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>codegenome</id>
-                    <url>https://artifacts.codegenomeproject.org/maven</url>
-                </pluginRepository>
-            </pluginRepositories>
-        </profile>
-
         <!--
             When you want to generate a TypeTable for use in JavaParser for JavaTemplate, run the following command:
             ./mvnw generate-resources -Ptypetable


### PR DESCRIPTION
Resolve OpenRewrite and Moderne artifacts from the Code Genome Project repository, which now requires credentials.

- **Maven**: declare the `codegenome` repository and plugin repository at the top level of `pom.xml`, so every build resolves from it. Pair it with a `codegenome` server in `~/.m2/settings.xml`.
- **Gradle**: rely on the `org.openrewrite.build.recipe-repositories` plugin, which declares the repository itself when `codegenomeUsername`/`codegenomePassword` are set. Without them it silently falls back to Maven Central, so the build now fails fast on the missing properties instead.
- **`java-object-diff`**: constrain it to `1.0.2`. The bom resolves `rewrite-core:8.89.0`, which requests `1.0.1` — a version the Code Genome Project repository does not publish. `1.0.2` is there, and is what `rewrite-core:8.90.4` already requests, so this constraint becomes removable once a bom pinning `8.90.x` is released.
- **README**: document credential setup for both build tools, since dependencies do not resolve without it.
