### PR TITLE
Use stable releases instead of milestones for test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>4.0.0-M1</version>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
 
@@ -151,14 +151,14 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>7.1.0-M1</version>
+            <version>7.0.9</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>7.1.0-M1</version>
+            <version>7.0.9</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -261,36 +261,6 @@
                     <url>https://artifacts.codegenomeproject.org/maven</url>
                 </pluginRepository>
             </pluginRepositories>
-        </profile>
-
-        <!--
-            When you want to generate a TypeTable for use in JavaParser for JavaTemplate, run the following command:
-            ./mvnw generate-resources -Ptypetable
-        -->
-        <profile>
-            <id>typetable</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.openrewrite.maven</groupId>
-                        <artifactId>rewrite-maven-plugin</artifactId>
-                        <configuration>
-                            <recipeArtifactCoordinates>
-                                junit:junit:3.8.1,
-                                org.jspecify:jspecify:1.0.0
-                            </recipeArtifactCoordinates>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>typetable</goal>
-                                </goals>
-                                <phase>generate-resources</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Switches the test-scoped dependencies back from milestone builds to the latest stable releases: AssertJ 4.0.0-M1 → 3.27.7 and Spring Core/Context 7.1.0-M1 → 7.0.9.

Also removes the `typetable` Maven profile, which was no longer used.