### PR TITLE
Exclude pre-release versions from weekly Maven version bumps

### DIFF
--- a/.github/workflows/maven-versions-use-latest-releases.yml
+++ b/.github/workflows/maven-versions-use-latest-releases.yml
@@ -30,7 +30,7 @@ jobs:
       - name: maven-versions-use-latest-releases
         run: |
           mvn versions:use-latest-releases
-          git diff-index --quiet HEAD pom.xml || (git commit -m "Use latest releases for Maven" pom.xml && git push origin main && rm -f pom.xml.versionsBackup)
+          git diff-index --quiet HEAD pom.xml || (git commit -m "Use latest releases for Maven" pom.xml && git push origin main)
         env:
           CODEGENOME_USERNAME: ${{ secrets.CODEGENOME_USERNAME }}
           CODEGENOME_TOKEN: ${{ secrets.CODEGENOME_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,24 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.21.0</version>
+                    <configuration>
+                        <generateBackupPoms>false</generateBackupPoms>
+                        <!-- Spring and AssertJ publish milestones to Maven Central; ignore any pre-release version -->
+                        <ignoredVersions>
+                            <ignoredVersion>(?i).*[.-]M\d+</ignoredVersion>
+                            <ignoredVersion>(?i).*[.-](RC|CR)\d*</ignoredVersion>
+                            <ignoredVersion>(?i).*[.-](alpha|beta|preview|dev|ea)[.\d-]*</ignoredVersion>
+                        </ignoredVersions>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- `versions:use-latest-releases` only filters out `-SNAPSHOT`, so the milestones Spring and AssertJ publish to Maven Central count as releases — which is how `4.0.0-M1` and `7.1.0-M1` kept landing back in the pom after #144 downgraded them.

This pins `versions-maven-plugin` in `pluginManagement` and configures `ignoredVersions` to skip milestone, RC/CR, alpha, beta, preview, dev and ea versions; putting it in the pom rather than on the workflow command line means it applies to local `mvn versions:*` runs too. It also sets `generateBackupPoms=false`, replacing the `rm -f pom.xml.versionsBackup` that only ever ran on the commit path.

Verified by running bare `./mvnw versions:use-latest-releases`: AssertJ and Spring now stay at 3.27.7 / 7.0.9, while a deliberately downgraded Lombok was still bumped back to 1.18.46, so stable updates keep flowing.