### PR TITLE
chore(deps): adopt rewrite-recipe-bom 3.38.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.openrewrite.recipe</groupId>
                 <artifactId>rewrite-recipe-bom</artifactId>
-                <version>3.37.0</version>
+                <version>3.38.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Bumps `org.openrewrite.recipe:rewrite-recipe-bom` from 3.37.0 to 3.38.0 in `pom.xml`.

Release notes: https://github.com/openrewrite/rewrite-recipe-bom/releases/tag/v3.38.0

Local verification was blocked by Maven Central rate limiting (HTTP 429), so this relies on CI to confirm the build.