### PR TITLE
Resolve the rewrite Gradle plugin from the Code Genome Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,33 @@ For Gradle, set `codegenomeUsername` and `codegenomePassword` in `~/.gradle/grad
 or use the matching `ORG_GRADLE_PROJECT_codegenomeUsername`/`ORG_GRADLE_PROJECT_codegenomePassword`
 environment variables. The build fails immediately when they are absent.
 
+The rewrite Gradle plugin comes from the Code Genome Project repository as well, so builds that
+apply it must declare that repository for plugin resolution. Its Gradle plugin marker is not
+published there, so map the plugin id onto the `org.openrewrite:plugin` module in `settings.gradle`:
+
+```groovy
+pluginManagement {
+    repositories {
+        maven {
+            name = "codegenome"
+            url = "https://artifacts.codegenomeproject.org/maven"
+            credentials(PasswordCredentials)
+        }
+        gradlePluginPortal()
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "org.openrewrite.rewrite") {
+                useModule("org.openrewrite:plugin:${requested.version}")
+            }
+        }
+    }
+}
+```
+
+The Gradle Plugin Portal stays in that list because the `org.openrewrite.build.*` plugins this
+project builds with are still published there.
+
 For Maven, add a `codegenome` server matching the repository id in `pom.xml` to your
 `~/.m2/settings.xml`:
 
@@ -111,7 +138,8 @@ In the pom.xml of a different project you wish to test your recipe out in, make 
 ```
 
 Unlike Maven, Gradle must be explicitly configured to resolve dependencies from Maven local.
-The root project of your Gradle build, make your recipe module a dependency of the `rewrite` configuration:
+The root project of your Gradle build, make your recipe module a dependency of the `rewrite` configuration,
+alongside the `pluginManagement` block shown [above](#code-genome-project-credentials) in `settings.gradle`:
 
 ```groovy
 plugins {
@@ -121,6 +149,11 @@ plugins {
 
 repositories {
     mavenLocal()
+    maven {
+        name = "codegenome"
+        url = "https://artifacts.codegenomeproject.org/maven"
+        credentials(PasswordCredentials)
+    }
     mavenCentral()
 }
 

--- a/init.gradle
+++ b/init.gradle
@@ -1,6 +1,13 @@
 initscript {
     repositories {
-        maven { url "https://plugins.gradle.org/m2" }
+        // The rewrite Gradle plugin is only published to the Code Genome Project repository;
+        // its third party dependencies still come from Maven Central.
+        maven {
+            name = "codegenome"
+            url = "https://artifacts.codegenomeproject.org/maven"
+            credentials(PasswordCredentials)
+        }
+        mavenCentral()
     }
     dependencies {
         classpath("org.openrewrite:plugin:latest.release")
@@ -14,6 +21,11 @@ rootProject {
     afterEvaluate {
         if (repositories.isEmpty()) {
             repositories {
+                maven {
+                    name = "codegenome"
+                    url = "https://artifacts.codegenomeproject.org/maven"
+                    credentials(PasswordCredentials)
+                }
                 mavenCentral()
             }
         }


### PR DESCRIPTION
The rewrite Gradle plugin is published to the Code Genome Project repository as `org.openrewrite:plugin`, so `init.gradle` now resolves it from there instead of the Gradle Plugin Portal, keeping `mavenCentral()` for third party transitives since CGP is not a mirror. Its Gradle plugin marker (`org.openrewrite.rewrite:org.openrewrite.rewrite.gradle.plugin`) is *not* published there, so the README documents the `eachPlugin`/`useModule` mapping consumers need to keep applying the plugin by id, plus the CGP repository in their `repositories` block.

Verified against CGP with credentials: `./gradlew --init-script init.gradle tasks --group rewrite` registers the rewrite tasks and `dependencies --configuration rewrite` resolves the full `rewrite-rewrite` tree; a scratch project using the documented `pluginManagement` block applies the plugin, and the same project without the `useModule` mapping fails. No `pom.xml` change is needed (Maven already has `codegenome` in `pluginRepositories`), and `settings.gradle.kts` is untouched because the `org.openrewrite.build.*` plugins are still Portal-only.